### PR TITLE
Fix warning generated by Netscaler::ServiceGroup#show

### DIFF
--- a/lib/netscaler/servicegroup.rb
+++ b/lib/netscaler/servicegroup.rb
@@ -21,7 +21,7 @@ module Netscaler
     ##
     # argument is optional, if left empty it will return all servicegroups
     def show(payload={}) # :arg: servicegroupname
-      return @netscaler.adapter.get("config/servicegroup/") if payload = {}
+      return @netscaler.adapter.get("config/servicegroup/") if payload.empty?
       return @netscaler.adapter.get("config/servicegroup/#{payload}")
     end
 

--- a/spec/lbvserver_spec.rb
+++ b/spec/lbvserver_spec.rb
@@ -52,7 +52,7 @@ describe Netscaler::Lb::Vserver do
     it 'when showing a particular lb vserver string is invalid' do
       expect {
         connection.lb.vserver.show('asdf')
-      }.should raise_error(TypeError, /convert/)
+      }.should raise_error(TypeError, /conver(t|sion)/)
     end
 
     it 'when showing a particular lb vserver :name is required' do


### PR DESCRIPTION
`Netscaler::ServiceGroup#show` was generating a warning due to the
assignment operator `=` being used to check equality. This was fixed by
calling the `.empty?` method on the `payload` hash.